### PR TITLE
[Bugfix] - destroyed hook, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You may install Vue Carousel 3d globally:
 import '@nanoandrew4/vue3-carousel-3d/dist/style.css'
 
 import { createApp } from 'vue'
-import { Carousel3dPlugin } from '@nanoandrew4/vue-carousel-3d'
+import { Carousel3dPlugin } from '@nanoandrew4/vue3-carousel-3d'
 
 const app = createApp(App)
 
@@ -38,7 +38,7 @@ This will make **&lt;Carousel3d&gt;** and **&lt;Slide&gt;** available to all com
 Include the Carousel 3d into your component using import:
 
 ``` js
-import { Carousel3d, Slide } from 'vue-carousel-3d';
+import { Carousel3d, Slide } from '@nanoandrew4/vue3-carousel-3d';
 
 export default {
   ...

--- a/src/components/Carousel3d.vue
+++ b/src/components/Carousel3d.vue
@@ -162,7 +162,7 @@ export default defineComponent({
       autoplayInterval: 0
     }
   },
-  destroyed() {
+  unmounted() {
     this.pauseAutoplay()
 
     this.$el.removeEventListener('mouseenter', this.pauseAutoplay)


### PR DESCRIPTION
1) Hook fix.
From Vuejs 3 Migration Guide:

- The `destroyed` lifecycle option has been renamed to `unmounted`

Source:
https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes

2) Updated Readme.md with the correct package name.