### PR TITLE
fix "main" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "Beautiful, flexible and touch supported 3D Carousel for Vue.js",
   "type": "module",
-  "main": "./dist/vue3-carousel-3d.umd.js",
+  "main": "./dist/vue3-carousel-3d.umd.cjs",
   "module": "./dist/vue3-carousel-3d.js",
   "types": "./dist/index.d.ts",
   "export": {

--- a/src/components/Carousel3d.vue
+++ b/src/components/Carousel3d.vue
@@ -127,7 +127,8 @@ export default defineComponent({
       default: 'left'
     },
     onMainSlideClick: {
-      type: Function
+      type: Function,
+      default: () => {}
     },
     oneDirectional: {
       type: Boolean,


### PR DESCRIPTION
Fixes incorrect "main" field in package.json. The current value "dist/vue3-carousel-3d.umd.js" points to a non-existent file, causing runtime errors in SSR apps. Updated to "dist/vue3-carousel-3d.umd.cjs", which matches the actual built file.

Also added default value for onMainClick function to avoid "not a function" error when clicking on current slide.